### PR TITLE
Removed Plugin Install

### DIFF
--- a/scripted-actions/windows-scripts/Install Zoom VDI client.ps1
+++ b/scripted-actions/windows-scripts/Install Zoom VDI client.ps1
@@ -3,14 +3,12 @@
 #tags: Nerdio, Apps install
 <# 
 Notes:
-This script installs the Zoom VDI client for use on WVD Session hosts, as well as the 
-Zoom AVD/WVD Media Plugin. 
+This script installs the Zoom VDI client for use on WVD Session hosts
 
 To install specific versions, update the URL variables below with links to the .msi installers.
 #>
 
 $ZoomClientUrl= "https://zoom.us/download/vdi/5.10.2/ZoomInstallerVDI.msi"
-$ZoomAvdPluginUrl = "https://zoom.us/download/vdi/5.10.2/ZoomWVDMediaPlugin.msi"
 
 
 # Start powershell logging
@@ -27,18 +25,12 @@ Write-host "Current time (UTC-0): $LogTime"
 mkdir "C:\Windows\Temp\zoom_sa\install" -Force
 
 Invoke-WebRequest -Uri $ZoomClientUrl -OutFile "C:\Windows\Temp\zoom_sa\install\ZoomInstallerVDI.msi" -UseBasicParsing
-Invoke-WebRequest -Uri $ZoomAvdPluginUrl -OutFile "C:\Windows\Temp\zoom_sa\install\ZoomAvdPluginVDI.msi" -UseBasicParsing
 
 # Install Zoom. Edit the argument list as desired for customized installs: https://support.zoom.us/hc/en-us/articles/201362163
 Write-Host "INFO: Installing Zoom client. . ."
 Start-Process C:\Windows\System32\msiexec.exe `
 -ArgumentList "/i C:\Windows\Temp\zoom_sa\install\ZoomInstallerVDI.msi /l*v C:\Windows\Temp\NMWLogs\ScriptedActions\zoom_sa\zoom_install_log.txt /qn /norestart" -Wait
 Write-Host "INFO: Zoom client install finished."
-
-Write-Host "INFO: Installing Zoom AVD Plugin. . ."
-Start-Process C:\Windows\System32\msiexec.exe `
--ArgumentList "/i C:\Windows\Temp\zoom_sa\install\ZoomAvdPluginVDI.msi /l*v C:\Windows\Temp\NMWLogs\ScriptedActions\zoom_sa\zoom_install_log.txt /qn /norestart" -Wait
-Write-Host "INFO: Zoom plugin install finished."
 
 # End Logging
 Stop-Transcript


### PR DESCRIPTION
The plugin does not need to be installed on the AVD host but on the client connecting. Installing both via the script just adds a bit of bloat to the host. Removed the bits for the plugin install. (though considering how much of our clients use intune, that can be thrown in its own script and leveraged there)

https://support.zoom.us/hc/en-us/articles/360031096531-Getting-started-with-VDI


> Installation of the Zoom application in a VDI environment requires administrator privileges and two installation steps
> The software must be installed within the Virtual Desktop, typically within the image on the VDI server.
> The Zoom Media Plugin is installed on each of the thin clients accessing the VDI.


Loving the product! Keep it up folks!