### PR TITLE
correct Adobe Reader parameters

### DIFF
--- a/scripted-actions/windows-scripts/Install Adobe Reader DC via Chocolatey.ps1
+++ b/scripted-actions/windows-scripts/Install Adobe Reader DC via Chocolatey.ps1
@@ -9,5 +9,4 @@ This script installs Adobe Reader DC via Chocolatey
 Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
 # Install Adobe Reader DC
-choco install adobereader /DesktopIcon -y
-
+choco install adobereader -y --params="/DesktopIcon"


### PR DESCRIPTION
The /DesktopIcon parameter is not passed to the Adobe installer without the chocolatey "--params" flag.