### PR TITLE
Update Delay host script with correct VM FQDN Tag

### DIFF
--- a/scripted-actions/azure-runbooks/Delay host availability in AVD for 10 minutes.ps1
+++ b/scripted-actions/azure-runbooks/Delay host availability in AVD for 10 minutes.ps1
@@ -22,7 +22,7 @@ Set-AzContext -SubscriptionId $AzureSubscriptionID
 $HostPoolRG = (Get-AzResource -ResourceId $HostpoolID).ResourceGroupName
 
 # Retrieve FQDN of session host by using Tag (FQDN required by WVD Powershell command)
-$HostFQDN = (Get-AzResource -ResourceGroupName $AzureResourceGroupName -Name $AzureVMName).Tags.NMW_VM_FQDN
+$HostFQDN = (Get-AzResource -ResourceGroupName $AzureResourceGroupName -Name $AzureVMName).Tags.WAP_VM_FQDN
 
 # Use FQDN to set session host to drain mode (Unavailable)
 Write-Output "INFO: Setting Session Host $HostFQDN to Drain-Mode"


### PR DESCRIPTION
The FQDN tag in this script seems to be incorrect. The VMs being deployed out by NMM for us have WAP_VM_FQDN. Updating the global script to contain this instead of NMW_VM_FDQN allows the script actually to work.

If the WAP_VM_FQDN is not correct either, please comment on the PR.