### PR TITLE
22191 defender canned polcies

### DIFF
--- a/intune-policies/application-control-policies/NMM Application Control (audit mode).json
+++ b/intune-policies/application-control-policies/NMM Application Control (audit mode).json
@@ -1,28 +1,25 @@
 {
-  "_wap_tags": "Defender for Endpoint",
-  "description": "Sets AppLocker to audit mode for Store apps and SmartLocker, doesn\u0027t block file overrides by SmartScreen, and disables SmartScreen prompts in the shell. This config audits app usage without enforcing restrictions or SmartScreen interventions.",
-  "displayName": "NMM Application Control (audit mode)",
-  "settingsDelta": [
-    {
-      "@odata.type": "#microsoft.graph.deviceManagementStringSettingInstance",
-      "id": "e95b52e5-3125-42d1-9d0e-efc6cd5ed78b",
-      "definitionId": "deviceConfiguration--windows10EndpointProtectionConfiguration_appLockerApplicationControl",
-      "valueJson": "\"auditComponentsStoreAppsAndSmartlocker\"",
-      "value": "auditComponentsStoreAppsAndSmartlocker"
-    },
-    {
-      "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
-      "id": "4c1080f3-6109-42b8-bc74-b5efc1ff7aa8",
-      "definitionId": "deviceConfiguration--windows10EndpointProtectionConfiguration_smartScreenBlockOverrideForFiles",
-      "valueJson": "false",
-      "value": false
-    },
-    {
-      "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
-      "id": "ed895b29-ab52-4e2c-820b-92696995e87c",
-      "definitionId": "deviceConfiguration--windows10EndpointProtectionConfiguration_smartScreenEnableInShell",
-      "valueJson": "false",
-      "value": false
-    }
-  ]
+    "_wap_tags": "Defender for Endpoint",
+    "description": "Sets AppLocker to audit mode for Store apps and SmartLocker, doesn\u0027t block file overrides by SmartScreen, and disables SmartScreen prompts in the shell. This config audits app usage without enforcing restrictions or SmartScreen interventions.",
+    "displayName": "NMM Application Control (audit mode)",
+    "settingsDelta": [
+        {
+            "@odata.type": "#microsoft.graph.deviceManagementStringSettingInstance",
+            "definitionId": "deviceConfiguration--windows10EndpointProtectionConfiguration_appLockerApplicationControl",
+            "valueJson": "\"auditComponentsStoreAppsAndSmartlocker\"",
+            "value": "auditComponentsStoreAppsAndSmartlocker"
+        },
+        {
+            "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
+            "definitionId": "deviceConfiguration--windows10EndpointProtectionConfiguration_smartScreenBlockOverrideForFiles",
+            "valueJson": "false",
+            "value": false
+        },
+        {
+            "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
+            "definitionId": "deviceConfiguration--windows10EndpointProtectionConfiguration_smartScreenEnableInShell",
+            "valueJson": "false",
+            "value": false
+        }
+    ]
 }

--- a/intune-policies/application-control-policies/NMM Application Control (audit mode).json
+++ b/intune-policies/application-control-policies/NMM Application Control (audit mode).json
@@ -1,0 +1,28 @@
+{
+  "_wap_tags": "Defender for Endpoint",
+  "description": "Sets AppLocker to audit mode for Store apps and SmartLocker, doesn\u0027t block file overrides by SmartScreen, and disables SmartScreen prompts in the shell. This config audits app usage without enforcing restrictions or SmartScreen interventions.",
+  "displayName": "NMM Application Control (audit mode)",
+  "settingsDelta": [
+    {
+      "@odata.type": "#microsoft.graph.deviceManagementStringSettingInstance",
+      "id": "e95b52e5-3125-42d1-9d0e-efc6cd5ed78b",
+      "definitionId": "deviceConfiguration--windows10EndpointProtectionConfiguration_appLockerApplicationControl",
+      "valueJson": "\"auditComponentsStoreAppsAndSmartlocker\"",
+      "value": "auditComponentsStoreAppsAndSmartlocker"
+    },
+    {
+      "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
+      "id": "4c1080f3-6109-42b8-bc74-b5efc1ff7aa8",
+      "definitionId": "deviceConfiguration--windows10EndpointProtectionConfiguration_smartScreenBlockOverrideForFiles",
+      "valueJson": "false",
+      "value": false
+    },
+    {
+      "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
+      "id": "ed895b29-ab52-4e2c-820b-92696995e87c",
+      "definitionId": "deviceConfiguration--windows10EndpointProtectionConfiguration_smartScreenEnableInShell",
+      "valueJson": "false",
+      "value": false
+    }
+  ]
+}

--- a/intune-policies/application-control-policies/NMM Enforce SmartScreen.json
+++ b/intune-policies/application-control-policies/NMM Enforce SmartScreen.json
@@ -1,0 +1,28 @@
+{
+  "_wap_tags": "Defender for Endpoint",
+  "description": "AppLocker is not configured, SmartScreen overrides for files are blocked, and SmartScreen is enabled in the shell, enforcing strict security measures against unverified files and applications.",
+  "displayName": "NMM Enforce SmartScreen",
+  "settingsDelta": [
+    {
+      "@odata.type": "#microsoft.graph.deviceManagementStringSettingInstance",
+      "id": "a03d28b6-ed63-488b-b1d3-ac9a89122606",
+      "definitionId": "deviceConfiguration--windows10EndpointProtectionConfiguration_appLockerApplicationControl",
+      "valueJson": "\"notConfigured\"",
+      "value": "notConfigured"
+    },
+    {
+      "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
+      "id": "add4f0ad-e26e-493b-905a-b339195dc8da",
+      "definitionId": "deviceConfiguration--windows10EndpointProtectionConfiguration_smartScreenBlockOverrideForFiles",
+      "valueJson": "true",
+      "value": true
+    },
+    {
+      "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
+      "id": "c351d4c9-e325-4dea-89e8-0524d0b12147",
+      "definitionId": "deviceConfiguration--windows10EndpointProtectionConfiguration_smartScreenEnableInShell",
+      "valueJson": "true",
+      "value": true
+    }
+  ]
+}

--- a/intune-policies/application-control-policies/NMM Enforce SmartScreen.json
+++ b/intune-policies/application-control-policies/NMM Enforce SmartScreen.json
@@ -1,28 +1,25 @@
 {
-  "_wap_tags": "Defender for Endpoint",
-  "description": "AppLocker is not configured, SmartScreen overrides for files are blocked, and SmartScreen is enabled in the shell, enforcing strict security measures against unverified files and applications.",
-  "displayName": "NMM Enforce SmartScreen",
-  "settingsDelta": [
-    {
-      "@odata.type": "#microsoft.graph.deviceManagementStringSettingInstance",
-      "id": "a03d28b6-ed63-488b-b1d3-ac9a89122606",
-      "definitionId": "deviceConfiguration--windows10EndpointProtectionConfiguration_appLockerApplicationControl",
-      "valueJson": "\"notConfigured\"",
-      "value": "notConfigured"
-    },
-    {
-      "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
-      "id": "add4f0ad-e26e-493b-905a-b339195dc8da",
-      "definitionId": "deviceConfiguration--windows10EndpointProtectionConfiguration_smartScreenBlockOverrideForFiles",
-      "valueJson": "true",
-      "value": true
-    },
-    {
-      "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
-      "id": "c351d4c9-e325-4dea-89e8-0524d0b12147",
-      "definitionId": "deviceConfiguration--windows10EndpointProtectionConfiguration_smartScreenEnableInShell",
-      "valueJson": "true",
-      "value": true
-    }
-  ]
+    "_wap_tags": "Defender for Endpoint",
+    "description": "AppLocker is not configured, SmartScreen overrides for files are blocked, and SmartScreen is enabled in the shell, enforcing strict security measures against unverified files and applications.",
+    "displayName": "NMM Enforce SmartScreen",
+    "settingsDelta": [
+        {
+            "@odata.type": "#microsoft.graph.deviceManagementStringSettingInstance",
+            "definitionId": "deviceConfiguration--windows10EndpointProtectionConfiguration_appLockerApplicationControl",
+            "valueJson": "\"notConfigured\"",
+            "value": "notConfigured"
+        },
+        {
+            "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
+            "definitionId": "deviceConfiguration--windows10EndpointProtectionConfiguration_smartScreenBlockOverrideForFiles",
+            "valueJson": "true",
+            "value": true
+        },
+        {
+            "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
+            "definitionId": "deviceConfiguration--windows10EndpointProtectionConfiguration_smartScreenEnableInShell",
+            "valueJson": "true",
+            "value": true
+        }
+    ]
 }

--- a/intune-policies/endpoint-detection-and-response-policies/NMM Defender onboarding for Windows 10_11 (with specific secret).json
+++ b/intune-policies/endpoint-detection-and-response-policies/NMM Defender onboarding for Windows 10_11 (with specific secret).json
@@ -1,0 +1,66 @@
+{
+
+  "description": "This onboard policy required specific secret in the secure variable with name OnBoardConfigurationSecret",
+  "name": "NMM Defender onboarding for Windows 10/11 (with specific secret)",
+  "platforms": "windows10",
+  "settingCount": 2,
+  "technologies": "mdm,microsoftSense",
+  "templateReference": {
+    "templateId": "0385b795-0f2f-44ac-8602-9f65bf6adede_1",
+    "templateFamily": "endpointSecurityEndpointDetectionAndResponse",
+    "templateDisplayName": "Endpoint detection and response",
+    "templateDisplayVersion": "Version 1"
+  },
+  "settings": [
+    {
+      "id": "0",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "device_vendor_msft_windowsadvancedthreatprotection_configurationtype",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "23ab0ea3-1b12-429a-8ed0-7390cf699160"
+        },
+        "choiceSettingValue": {
+          "value": "device_vendor_msft_windowsadvancedthreatprotection_configurationtype_autofromconnector",
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "e5c7c98c-c854-4140-836e-bd22db59d651",
+            "useTemplateDefault": false
+          },
+          "children": [
+            {
+              "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
+              "settingDefinitionId": "device_vendor_msft_windowsadvancedthreatprotection_onboarding_fromconnector",
+              "settingInstanceTemplateReference": null,
+              "simpleSettingValue": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationSecretSettingValue",
+                "settingValueTemplateReference": null,
+                "value": "{$SecureVars.OnBoardConfigurationSecret}",
+                "valueState": "encryptedValueToken"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "1",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "device_vendor_msft_windowsadvancedthreatprotection_configuration_samplesharing",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "6998c81e-2814-4f5e-b492-a6159128a97b"
+        },
+        "choiceSettingValue": {
+          "value": "device_vendor_msft_windowsadvancedthreatprotection_configuration_samplesharing_1",
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "f72c326c-7c5b-4224-b890-0b9b54522bd9",
+            "useTemplateDefault": false
+          },
+          "children": [
+
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/intune-policies/endpoint-detection-and-response-policies/NMM Defender onboarding for Windows 10_11 (with specific secret).json
+++ b/intune-policies/endpoint-detection-and-response-policies/NMM Defender onboarding for Windows 10_11 (with specific secret).json
@@ -1,66 +1,64 @@
 {
-
-  "description": "This onboard policy required specific secret in the secure variable with name OnBoardConfigurationSecret",
-  "name": "NMM Defender onboarding for Windows 10/11 (with specific secret)",
-  "platforms": "windows10",
-  "settingCount": 2,
-  "technologies": "mdm,microsoftSense",
-  "templateReference": {
-    "templateId": "0385b795-0f2f-44ac-8602-9f65bf6adede_1",
-    "templateFamily": "endpointSecurityEndpointDetectionAndResponse",
-    "templateDisplayName": "Endpoint detection and response",
-    "templateDisplayVersion": "Version 1"
-  },
-  "settings": [
-    {
-      "id": "0",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "device_vendor_msft_windowsadvancedthreatprotection_configurationtype",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "23ab0ea3-1b12-429a-8ed0-7390cf699160"
-        },
-        "choiceSettingValue": {
-          "value": "device_vendor_msft_windowsadvancedthreatprotection_configurationtype_autofromconnector",
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "e5c7c98c-c854-4140-836e-bd22db59d651",
-            "useTemplateDefault": false
-          },
-          "children": [
-            {
-              "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
-              "settingDefinitionId": "device_vendor_msft_windowsadvancedthreatprotection_onboarding_fromconnector",
-              "settingInstanceTemplateReference": null,
-              "simpleSettingValue": {
-                "@odata.type": "#microsoft.graph.deviceManagementConfigurationSecretSettingValue",
-                "settingValueTemplateReference": null,
-                "value": "{$SecureVars.OnBoardConfigurationSecret}",
-                "valueState": "encryptedValueToken"
-              }
-            }
-          ]
-        }
-      }
+    "_wap_tags": "Defender for Endpoint",
+    "description": "This onboard policy required specific secret in the secure variable with name OnBoardConfigurationSecret",
+    "name": "NMM Defender onboarding for Windows 10/11 (with specific secret)",
+    "platforms": "windows10",
+    "settingCount": 2,
+    "technologies": "mdm,microsoftSense",
+    "templateReference": {
+        "templateId": "0385b795-0f2f-44ac-8602-9f65bf6adede_1",
+        "templateFamily": "endpointSecurityEndpointDetectionAndResponse",
+        "templateDisplayName": "Endpoint detection and response",
+        "templateDisplayVersion": "Version 1"
     },
-    {
-      "id": "1",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "device_vendor_msft_windowsadvancedthreatprotection_configuration_samplesharing",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "6998c81e-2814-4f5e-b492-a6159128a97b"
+    "settings": [
+        {
+            "id": "0",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "device_vendor_msft_windowsadvancedthreatprotection_configurationtype",
+                "settingInstanceTemplateReference": {
+                    "settingInstanceTemplateId": "23ab0ea3-1b12-429a-8ed0-7390cf699160"
+                },
+                "choiceSettingValue": {
+                    "value": "device_vendor_msft_windowsadvancedthreatprotection_configurationtype_autofromconnector",
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "e5c7c98c-c854-4140-836e-bd22db59d651",
+                        "useTemplateDefault": false
+                    },
+                    "children": [
+                        {
+                            "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
+                            "settingDefinitionId": "device_vendor_msft_windowsadvancedthreatprotection_onboarding_fromconnector",
+                            "settingInstanceTemplateReference": null,
+                            "simpleSettingValue": {
+                                "@odata.type": "#microsoft.graph.deviceManagementConfigurationSecretSettingValue",
+                                "settingValueTemplateReference": null,
+                                "value": "{$SecureVars.OnBoardConfigurationSecret}",
+                                "valueState": "encryptedValueToken"
+                            }
+                        }
+                    ]
+                }
+            }
         },
-        "choiceSettingValue": {
-          "value": "device_vendor_msft_windowsadvancedthreatprotection_configuration_samplesharing_1",
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "f72c326c-7c5b-4224-b890-0b9b54522bd9",
-            "useTemplateDefault": false
-          },
-          "children": [
-
-          ]
+        {
+            "id": "1",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "device_vendor_msft_windowsadvancedthreatprotection_configuration_samplesharing",
+                "settingInstanceTemplateReference": {
+                    "settingInstanceTemplateId": "6998c81e-2814-4f5e-b492-a6159128a97b"
+                },
+                "choiceSettingValue": {
+                    "value": "device_vendor_msft_windowsadvancedthreatprotection_configuration_samplesharing_1",
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "f72c326c-7c5b-4224-b890-0b9b54522bd9",
+                        "useTemplateDefault": false
+                    },
+                    "children": []
+                }
+            }
         }
-      }
-    }
-  ]
+    ]
 }

--- a/intune-policies/endpoint-detection-and-response-policies/NMM Defender onboarding for Windows 10_11.json
+++ b/intune-policies/endpoint-detection-and-response-policies/NMM Defender onboarding for Windows 10_11.json
@@ -1,0 +1,65 @@
+{
+  "description": "",
+  "name": "NMM Defender onboarding for Windows 10/11 autoconnect",
+  "platforms": "windows10",
+  "settingCount": 2,
+  "technologies": "mdm,microsoftSense",
+  "templateReference": {
+    "templateId": "0385b795-0f2f-44ac-8602-9f65bf6adede_1",
+    "templateFamily": "endpointSecurityEndpointDetectionAndResponse",
+    "templateDisplayName": "Endpoint detection and response",
+    "templateDisplayVersion": "Version 1"
+  },
+  "settings": [
+    {
+      "id": "0",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "device_vendor_msft_windowsadvancedthreatprotection_configurationtype",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "23ab0ea3-1b12-429a-8ed0-7390cf699160"
+        },
+        "choiceSettingValue": {
+          "value": "device_vendor_msft_windowsadvancedthreatprotection_configurationtype_autofromconnector",
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "e5c7c98c-c854-4140-836e-bd22db59d651",
+            "useTemplateDefault": false
+          },
+          "children": [
+            {
+              "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
+              "settingDefinitionId": "device_vendor_msft_windowsadvancedthreatprotection_onboarding_fromconnector",
+              "settingInstanceTemplateReference": null,
+              "simpleSettingValue": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationSecretSettingValue",
+                "settingValueTemplateReference": null,
+                "value": "Microsoft ATP connector enabled",
+                "valueState": "NotEncrypted"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "1",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "device_vendor_msft_windowsadvancedthreatprotection_configuration_samplesharing",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "6998c81e-2814-4f5e-b492-a6159128a97b"
+        },
+        "choiceSettingValue": {
+          "value": "device_vendor_msft_windowsadvancedthreatprotection_configuration_samplesharing_1",
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "f72c326c-7c5b-4224-b890-0b9b54522bd9",
+            "useTemplateDefault": false
+          },
+          "children": [
+
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/intune-policies/endpoint-detection-and-response-policies/NMM Defender onboarding for Windows 10_11.json
+++ b/intune-policies/endpoint-detection-and-response-policies/NMM Defender onboarding for Windows 10_11.json
@@ -1,65 +1,64 @@
 {
-  "description": "",
-  "name": "NMM Defender onboarding for Windows 10/11 autoconnect",
-  "platforms": "windows10",
-  "settingCount": 2,
-  "technologies": "mdm,microsoftSense",
-  "templateReference": {
-    "templateId": "0385b795-0f2f-44ac-8602-9f65bf6adede_1",
-    "templateFamily": "endpointSecurityEndpointDetectionAndResponse",
-    "templateDisplayName": "Endpoint detection and response",
-    "templateDisplayVersion": "Version 1"
-  },
-  "settings": [
-    {
-      "id": "0",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "device_vendor_msft_windowsadvancedthreatprotection_configurationtype",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "23ab0ea3-1b12-429a-8ed0-7390cf699160"
-        },
-        "choiceSettingValue": {
-          "value": "device_vendor_msft_windowsadvancedthreatprotection_configurationtype_autofromconnector",
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "e5c7c98c-c854-4140-836e-bd22db59d651",
-            "useTemplateDefault": false
-          },
-          "children": [
-            {
-              "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
-              "settingDefinitionId": "device_vendor_msft_windowsadvancedthreatprotection_onboarding_fromconnector",
-              "settingInstanceTemplateReference": null,
-              "simpleSettingValue": {
-                "@odata.type": "#microsoft.graph.deviceManagementConfigurationSecretSettingValue",
-                "settingValueTemplateReference": null,
-                "value": "Microsoft ATP connector enabled",
-                "valueState": "NotEncrypted"
-              }
-            }
-          ]
-        }
-      }
+    "_wap_tags": "Defender for Endpoint",
+    "description": "",
+    "name": "NMM Defender onboarding for Windows 10/11 autoconnect",
+    "platforms": "windows10",
+    "settingCount": 2,
+    "technologies": "mdm,microsoftSense",
+    "templateReference": {
+        "templateId": "0385b795-0f2f-44ac-8602-9f65bf6adede_1",
+        "templateFamily": "endpointSecurityEndpointDetectionAndResponse",
+        "templateDisplayName": "Endpoint detection and response",
+        "templateDisplayVersion": "Version 1"
     },
-    {
-      "id": "1",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "device_vendor_msft_windowsadvancedthreatprotection_configuration_samplesharing",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "6998c81e-2814-4f5e-b492-a6159128a97b"
+    "settings": [
+        {
+            "id": "0",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "device_vendor_msft_windowsadvancedthreatprotection_configurationtype",
+                "settingInstanceTemplateReference": {
+                    "settingInstanceTemplateId": "23ab0ea3-1b12-429a-8ed0-7390cf699160"
+                },
+                "choiceSettingValue": {
+                    "value": "device_vendor_msft_windowsadvancedthreatprotection_configurationtype_autofromconnector",
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "e5c7c98c-c854-4140-836e-bd22db59d651",
+                        "useTemplateDefault": false
+                    },
+                    "children": [
+                        {
+                            "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
+                            "settingDefinitionId": "device_vendor_msft_windowsadvancedthreatprotection_onboarding_fromconnector",
+                            "settingInstanceTemplateReference": null,
+                            "simpleSettingValue": {
+                                "@odata.type": "#microsoft.graph.deviceManagementConfigurationSecretSettingValue",
+                                "settingValueTemplateReference": null,
+                                "value": "Microsoft ATP connector enabled",
+                                "valueState": "NotEncrypted"
+                            }
+                        }
+                    ]
+                }
+            }
         },
-        "choiceSettingValue": {
-          "value": "device_vendor_msft_windowsadvancedthreatprotection_configuration_samplesharing_1",
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "f72c326c-7c5b-4224-b890-0b9b54522bd9",
-            "useTemplateDefault": false
-          },
-          "children": [
-
-          ]
+        {
+            "id": "1",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "device_vendor_msft_windowsadvancedthreatprotection_configuration_samplesharing",
+                "settingInstanceTemplateReference": {
+                    "settingInstanceTemplateId": "6998c81e-2814-4f5e-b492-a6159128a97b"
+                },
+                "choiceSettingValue": {
+                    "value": "device_vendor_msft_windowsadvancedthreatprotection_configuration_samplesharing_1",
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "f72c326c-7c5b-4224-b890-0b9b54522bd9",
+                        "useTemplateDefault": false
+                    },
+                    "children": []
+                }
+            }
         }
-      }
-    }
-  ]
+    ]
 }

--- a/intune-policies/macos-firewall-policies/NMM macOS Firewall.json
+++ b/intune-policies/macos-firewall-policies/NMM macOS Firewall.json
@@ -1,0 +1,34 @@
+{
+  "_wap_tags": "Defender for Endpoint",
+  "description": "Activates macOS firewall, blocks all incoming connections, and leaves stealth mode disabled, indicating the device remains visible on the network. No specific applications are configured to bypass the firewall, allowing for separate customization.",
+  "displayName": "NMM macOS Firewall",
+  "settingsDelta": [
+    {
+      "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
+      "id": "e118dc4b-65f8-4f6a-8b47-ef8a625563fa",
+      "definitionId": "deviceConfiguration--macOSEndpointProtectionConfiguration_firewallEnabled",
+      "valueJson": "true",
+      "value": true
+    },
+    {
+      "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
+      "id": "24273c57-93f0-4c3f-ad71-1e834062092d",
+      "definitionId": "deviceConfiguration--macOSEndpointProtectionConfiguration_firewallBlockAllIncoming",
+      "valueJson": "true",
+      "value": true
+    },
+    {
+      "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
+      "id": "1b621574-6e6c-4f5e-9b56-8ee2954c4242",
+      "definitionId": "deviceConfiguration--macOSEndpointProtectionConfiguration_firewallEnableStealthMode",
+      "valueJson": "false",
+      "value": false
+    },
+    {
+      "@odata.type": "#microsoft.graph.deviceManagementCollectionSettingInstance",
+      "id": "9f355684-273b-4a11-b559-f172e97c6f1c",
+      "definitionId": "deviceConfiguration--macOSEndpointProtectionConfiguration_firewallApplications",
+      "valueJson": "null"
+    }
+  ]
+}

--- a/intune-policies/macos-firewall-policies/NMM macOS Firewall.json
+++ b/intune-policies/macos-firewall-policies/NMM macOS Firewall.json
@@ -1,34 +1,30 @@
 {
-  "_wap_tags": "Defender for Endpoint",
-  "description": "Activates macOS firewall, blocks all incoming connections, and leaves stealth mode disabled, indicating the device remains visible on the network. No specific applications are configured to bypass the firewall, allowing for separate customization.",
-  "displayName": "NMM macOS Firewall",
-  "settingsDelta": [
-    {
-      "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
-      "id": "e118dc4b-65f8-4f6a-8b47-ef8a625563fa",
-      "definitionId": "deviceConfiguration--macOSEndpointProtectionConfiguration_firewallEnabled",
-      "valueJson": "true",
-      "value": true
-    },
-    {
-      "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
-      "id": "24273c57-93f0-4c3f-ad71-1e834062092d",
-      "definitionId": "deviceConfiguration--macOSEndpointProtectionConfiguration_firewallBlockAllIncoming",
-      "valueJson": "true",
-      "value": true
-    },
-    {
-      "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
-      "id": "1b621574-6e6c-4f5e-9b56-8ee2954c4242",
-      "definitionId": "deviceConfiguration--macOSEndpointProtectionConfiguration_firewallEnableStealthMode",
-      "valueJson": "false",
-      "value": false
-    },
-    {
-      "@odata.type": "#microsoft.graph.deviceManagementCollectionSettingInstance",
-      "id": "9f355684-273b-4a11-b559-f172e97c6f1c",
-      "definitionId": "deviceConfiguration--macOSEndpointProtectionConfiguration_firewallApplications",
-      "valueJson": "null"
-    }
-  ]
+    "_wap_tags": "Defender for Endpoint",
+    "description": "Activates macOS firewall, blocks all incoming connections, and leaves stealth mode disabled, indicating the device remains visible on the network. No specific applications are configured to bypass the firewall, allowing for separate customization.",
+    "displayName": "NMM macOS Firewall",
+    "settingsDelta": [
+        {
+            "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
+            "definitionId": "deviceConfiguration--macOSEndpointProtectionConfiguration_firewallEnabled",
+            "valueJson": "true",
+            "value": true
+        },
+        {
+            "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
+            "definitionId": "deviceConfiguration--macOSEndpointProtectionConfiguration_firewallBlockAllIncoming",
+            "valueJson": "true",
+            "value": true
+        },
+        {
+            "@odata.type": "#microsoft.graph.deviceManagementBooleanSettingInstance",
+            "definitionId": "deviceConfiguration--macOSEndpointProtectionConfiguration_firewallEnableStealthMode",
+            "valueJson": "false",
+            "value": false
+        },
+        {
+            "@odata.type": "#microsoft.graph.deviceManagementCollectionSettingInstance",
+            "definitionId": "deviceConfiguration--macOSEndpointProtectionConfiguration_firewallApplications",
+            "valueJson": "null"
+        }
+    ]
 }

--- a/intune-policies/microsoft-defender-antivirus-policies/NMM Defender Antivirus for macOS.json
+++ b/intune-policies/microsoft-defender-antivirus-policies/NMM Defender Antivirus for macOS.json
@@ -1,365 +1,333 @@
 {
-  "_wap_tags": "Defender for Endpoint",
-  "description": "This policy configures Microsoft Defender Antivirus settings on macOS devices to enhance security. It includes settings for exclusions, threat type settings merge policy, maximum on-demand scan threads, scanning after definition updates, archive scanning, antivirus engine enforcement level, enabling the antivirus, automatic sample submission, diagnostic level, automatic definition update, general enforcement level, tamper protection enforcement level, consumer experience adjustments, hiding the status menu icon, and user-initiated feedback.",
-  "name": "NMM Defender Antivirus for macOS",
-  "platforms": "macOS",
-  "settingCount": 16,
-  "technologies": "mdm,microsoftSense",
-  "templateReference": {
-    "templateId": "2d345ec2-c817-49e5-9156-3ed416dc972a_1",
-    "templateFamily": "endpointSecurityAntivirus",
-    "templateDisplayName": "Microsoft Defender Antivirus",
-    "templateDisplayVersion": "Version 1"
-  },
-  "settings": [
-    {
-      "id": "0",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "com.apple.managedclient.preferences_exclusionsmergepolicy",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "c07a6983-ac3e-4f38-be45-20954638dabd"
-        },
-        "choiceSettingValue": {
-          "value": "com.apple.managedclient.preferences_exclusionsmergepolicy_1",
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "effc409a-9169-43f0-a807-2a388875cf99",
-            "useTemplateDefault": false
-          },
-          "children": [
-
-          ]
-        }
-      }
+    "_wap_tags": "Defender for Endpoint",
+    "description": "This policy configures Microsoft Defender Antivirus settings on macOS devices to enhance security. It includes settings for exclusions, threat type settings merge policy, maximum on-demand scan threads, scanning after definition updates, archive scanning, antivirus engine enforcement level, enabling the antivirus, automatic sample submission, diagnostic level, automatic definition update, general enforcement level, tamper protection enforcement level, consumer experience adjustments, hiding the status menu icon, and user-initiated feedback.",
+    "name": "NMM Defender Antivirus for macOS",
+    "platforms": "macOS",
+    "settingCount": 16,
+    "technologies": "mdm,microsoftSense",
+    "templateReference": {
+        "templateId": "2d345ec2-c817-49e5-9156-3ed416dc972a_1",
+        "templateFamily": "endpointSecurityAntivirus",
+        "templateDisplayName": "Microsoft Defender Antivirus",
+        "templateDisplayVersion": "Version 1"
     },
-    {
-      "id": "1",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance",
-        "settingDefinitionId": "com.apple.managedclient.preferences_threattypesettings",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "f2df12de-2704-4a13-9e10-21f4857122aa"
-        },
-        "groupSettingCollectionValue": [
-          {
-            "settingValueTemplateReference": null,
-            "children": [
-              {
+    "settings": [
+        {
+            "id": "0",
+            "settingInstance": {
                 "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-                "settingDefinitionId": "com.apple.managedclient.preferences_threattypesettings_item_key",
+                "settingDefinitionId": "com.apple.managedclient.preferences_exclusionsmergepolicy",
                 "settingInstanceTemplateReference": {
-                  "settingInstanceTemplateId": "675e2ada-1e8f-46eb-9348-ab0707c86ed0"
+                    "settingInstanceTemplateId": "c07a6983-ac3e-4f38-be45-20954638dabd"
                 },
                 "choiceSettingValue": {
-                  "value": "com.apple.managedclient.preferences_threattypesettings_item_key_0",
-                  "settingValueTemplateReference": {
-                    "settingValueTemplateId": "45c09bfc-8cbd-4118-9396-17427d8c5795",
-                    "useTemplateDefault": false
-                  },
-                  "children": [
-
-                  ]
+                    "value": "com.apple.managedclient.preferences_exclusionsmergepolicy_1",
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "effc409a-9169-43f0-a807-2a388875cf99",
+                        "useTemplateDefault": false
+                    },
+                    "children": []
                 }
-              },
-              {
-                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-                "settingDefinitionId": "com.apple.managedclient.preferences_threattypesettings_item_value",
+            }
+        },
+        {
+            "id": "1",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance",
+                "settingDefinitionId": "com.apple.managedclient.preferences_threattypesettings",
                 "settingInstanceTemplateReference": {
-                  "settingInstanceTemplateId": "347d727a-70f7-4d22-af3d-5571052ce9d5"
+                    "settingInstanceTemplateId": "f2df12de-2704-4a13-9e10-21f4857122aa"
+                },
+                "groupSettingCollectionValue": [
+                    {
+                        "settingValueTemplateReference": null,
+                        "children": [
+                            {
+                                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                                "settingDefinitionId": "com.apple.managedclient.preferences_threattypesettings_item_key",
+                                "settingInstanceTemplateReference": {
+                                    "settingInstanceTemplateId": "675e2ada-1e8f-46eb-9348-ab0707c86ed0"
+                                },
+                                "choiceSettingValue": {
+                                    "value": "com.apple.managedclient.preferences_threattypesettings_item_key_0",
+                                    "settingValueTemplateReference": {
+                                        "settingValueTemplateId": "45c09bfc-8cbd-4118-9396-17427d8c5795",
+                                        "useTemplateDefault": false
+                                    },
+                                    "children": []
+                                }
+                            },
+                            {
+                                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                                "settingDefinitionId": "com.apple.managedclient.preferences_threattypesettings_item_value",
+                                "settingInstanceTemplateReference": {
+                                    "settingInstanceTemplateId": "347d727a-70f7-4d22-af3d-5571052ce9d5"
+                                },
+                                "choiceSettingValue": {
+                                    "value": "com.apple.managedclient.preferences_threattypesettings_item_value_0",
+                                    "settingValueTemplateReference": {
+                                        "settingValueTemplateId": "2d7b917e-affe-47d4-aa42-8468bc109dad",
+                                        "useTemplateDefault": false
+                                    },
+                                    "children": []
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "id": "2",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "com.apple.managedclient.preferences_threattypesettingsmergepolicy",
+                "settingInstanceTemplateReference": {
+                    "settingInstanceTemplateId": "65d9ddaf-0552-4e40-8575-71dd54b2ccb4"
                 },
                 "choiceSettingValue": {
-                  "value": "com.apple.managedclient.preferences_threattypesettings_item_value_0",
-                  "settingValueTemplateReference": {
-                    "settingValueTemplateId": "2d7b917e-affe-47d4-aa42-8468bc109dad",
-                    "useTemplateDefault": false
-                  },
-                  "children": [
-
-                  ]
+                    "value": "com.apple.managedclient.preferences_threattypesettingsmergepolicy_1",
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "613bcf39-69ec-4a1f-8822-07789ae7f8cb",
+                        "useTemplateDefault": false
+                    },
+                    "children": []
                 }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "id": "2",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "com.apple.managedclient.preferences_threattypesettingsmergepolicy",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "65d9ddaf-0552-4e40-8575-71dd54b2ccb4"
+            }
         },
-        "choiceSettingValue": {
-          "value": "com.apple.managedclient.preferences_threattypesettingsmergepolicy_1",
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "613bcf39-69ec-4a1f-8822-07789ae7f8cb",
-            "useTemplateDefault": false
-          },
-          "children": [
-
-          ]
-        }
-      }
-    },
-    {
-      "id": "3",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
-        "settingDefinitionId": "com.apple.managedclient.preferences_maximumondemandscanthreads",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "e02fd3ba-4146-4b7d-9c7f-dffec96465e5"
+        {
+            "id": "3",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
+                "settingDefinitionId": "com.apple.managedclient.preferences_maximumondemandscanthreads",
+                "settingInstanceTemplateReference": {
+                    "settingInstanceTemplateId": "e02fd3ba-4146-4b7d-9c7f-dffec96465e5"
+                },
+                "simpleSettingValue": {
+                    "@odata.type": "#microsoft.graph.deviceManagementConfigurationIntegerSettingValue",
+                    "value": 2,
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "fe25bbb2-f6de-480a-9153-11f90d7dab4e",
+                        "useTemplateDefault": false
+                    }
+                }
+            }
         },
-        "simpleSettingValue": {
-          "@odata.type": "#microsoft.graph.deviceManagementConfigurationIntegerSettingValue",
-          "value": 2,
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "fe25bbb2-f6de-480a-9153-11f90d7dab4e",
-            "useTemplateDefault": false
-          }
-        }
-      }
-    },
-    {
-      "id": "4",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "com.apple.managedclient.preferences_scanafterdefinitionupdate",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "65bc7d9e-a0fc-4e3f-b464-550c30589e3c"
+        {
+            "id": "4",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "com.apple.managedclient.preferences_scanafterdefinitionupdate",
+                "settingInstanceTemplateReference": {
+                    "settingInstanceTemplateId": "65bc7d9e-a0fc-4e3f-b464-550c30589e3c"
+                },
+                "choiceSettingValue": {
+                    "value": "com.apple.managedclient.preferences_scanafterdefinitionupdate_true",
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "1d05f27d-cc04-44a3-82f8-91df943b03e4",
+                        "useTemplateDefault": false
+                    },
+                    "children": []
+                }
+            }
         },
-        "choiceSettingValue": {
-          "value": "com.apple.managedclient.preferences_scanafterdefinitionupdate_true",
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "1d05f27d-cc04-44a3-82f8-91df943b03e4",
-            "useTemplateDefault": false
-          },
-          "children": [
-
-          ]
-        }
-      }
-    },
-    {
-      "id": "5",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "com.apple.managedclient.preferences_scanarchives",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "27ca9434-85a0-4175-999d-bbef8eb8d066"
+        {
+            "id": "5",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "com.apple.managedclient.preferences_scanarchives",
+                "settingInstanceTemplateReference": {
+                    "settingInstanceTemplateId": "27ca9434-85a0-4175-999d-bbef8eb8d066"
+                },
+                "choiceSettingValue": {
+                    "value": "com.apple.managedclient.preferences_scanarchives_true",
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "26bb4b38-6e8a-4e3d-9045-81314475b3fe",
+                        "useTemplateDefault": false
+                    },
+                    "children": []
+                }
+            }
         },
-        "choiceSettingValue": {
-          "value": "com.apple.managedclient.preferences_scanarchives_true",
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "26bb4b38-6e8a-4e3d-9045-81314475b3fe",
-            "useTemplateDefault": false
-          },
-          "children": [
-
-          ]
-        }
-      }
-    },
-    {
-      "id": "6",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "com.apple.managedclient.preferences_enforcementlevel_antivirusengine",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "a1bf7f4c-196e-4930-8395-a9b496433322"
+        {
+            "id": "6",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "com.apple.managedclient.preferences_enforcementlevel_antivirusengine",
+                "settingInstanceTemplateReference": {
+                    "settingInstanceTemplateId": "a1bf7f4c-196e-4930-8395-a9b496433322"
+                },
+                "choiceSettingValue": {
+                    "value": "com.apple.managedclient.preferences_enforcementlevel_antivirusengine_2",
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "440003a2-8406-47bb-a785-a45869556ead",
+                        "useTemplateDefault": false
+                    },
+                    "children": []
+                }
+            }
         },
-        "choiceSettingValue": {
-          "value": "com.apple.managedclient.preferences_enforcementlevel_antivirusengine_2",
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "440003a2-8406-47bb-a785-a45869556ead",
-            "useTemplateDefault": false
-          },
-          "children": [
-
-          ]
-        }
-      }
-    },
-    {
-      "id": "7",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "com.apple.managedclient.preferences_enabled",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "9e424cc6-35b9-48ef-863c-73295aa9d2d7"
+        {
+            "id": "7",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "com.apple.managedclient.preferences_enabled",
+                "settingInstanceTemplateReference": {
+                    "settingInstanceTemplateId": "9e424cc6-35b9-48ef-863c-73295aa9d2d7"
+                },
+                "choiceSettingValue": {
+                    "value": "com.apple.managedclient.preferences_enabled_true",
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "7ea0a2aa-0953-4340-b590-522f040b0da3",
+                        "useTemplateDefault": false
+                    },
+                    "children": []
+                }
+            }
         },
-        "choiceSettingValue": {
-          "value": "com.apple.managedclient.preferences_enabled_true",
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "7ea0a2aa-0953-4340-b590-522f040b0da3",
-            "useTemplateDefault": false
-          },
-          "children": [
-
-          ]
-        }
-      }
-    },
-    {
-      "id": "8",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "com.apple.managedclient.preferences_automaticsamplesubmission",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "d5563bad-08c5-47de-8bbb-5d44e0f9a23a"
+        {
+            "id": "8",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "com.apple.managedclient.preferences_automaticsamplesubmission",
+                "settingInstanceTemplateReference": {
+                    "settingInstanceTemplateId": "d5563bad-08c5-47de-8bbb-5d44e0f9a23a"
+                },
+                "choiceSettingValue": {
+                    "value": "com.apple.managedclient.preferences_automaticsamplesubmission_true",
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "de57abd5-1a87-463e-96e7-e117524003ba",
+                        "useTemplateDefault": false
+                    },
+                    "children": []
+                }
+            }
         },
-        "choiceSettingValue": {
-          "value": "com.apple.managedclient.preferences_automaticsamplesubmission_true",
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "de57abd5-1a87-463e-96e7-e117524003ba",
-            "useTemplateDefault": false
-          },
-          "children": [
-
-          ]
-        }
-      }
-    },
-    {
-      "id": "9",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "com.apple.managedclient.preferences_diagnosticlevel",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "c7a9a79b-20cf-461f-8021-94702a32543b"
+        {
+            "id": "9",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "com.apple.managedclient.preferences_diagnosticlevel",
+                "settingInstanceTemplateReference": {
+                    "settingInstanceTemplateId": "c7a9a79b-20cf-461f-8021-94702a32543b"
+                },
+                "choiceSettingValue": {
+                    "value": "com.apple.managedclient.preferences_diagnosticlevel_1",
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "5fc10db6-9ee5-434a-9ed0-1382bf72969e",
+                        "useTemplateDefault": false
+                    },
+                    "children": []
+                }
+            }
         },
-        "choiceSettingValue": {
-          "value": "com.apple.managedclient.preferences_diagnosticlevel_1",
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "5fc10db6-9ee5-434a-9ed0-1382bf72969e",
-            "useTemplateDefault": false
-          },
-          "children": [
-
-          ]
-        }
-      }
-    },
-    {
-      "id": "10",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "com.apple.managedclient.preferences_automaticdefinitionupdateenabled",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "cc18c6dc-dca5-4845-9c78-c718c9447ddd"
+        {
+            "id": "10",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "com.apple.managedclient.preferences_automaticdefinitionupdateenabled",
+                "settingInstanceTemplateReference": {
+                    "settingInstanceTemplateId": "cc18c6dc-dca5-4845-9c78-c718c9447ddd"
+                },
+                "choiceSettingValue": {
+                    "value": "com.apple.managedclient.preferences_automaticdefinitionupdateenabled_true",
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "112fd4a8-1393-49b6-9569-0d37266a6ad3",
+                        "useTemplateDefault": false
+                    },
+                    "children": []
+                }
+            }
         },
-        "choiceSettingValue": {
-          "value": "com.apple.managedclient.preferences_automaticdefinitionupdateenabled_true",
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "112fd4a8-1393-49b6-9569-0d37266a6ad3",
-            "useTemplateDefault": false
-          },
-          "children": [
-
-          ]
-        }
-      }
-    },
-    {
-      "id": "11",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "com.apple.managedclient.preferences_enforcementlevel",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "94f6f35c-4cee-4a61-930a-491b698c790a"
+        {
+            "id": "11",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "com.apple.managedclient.preferences_enforcementlevel",
+                "settingInstanceTemplateReference": {
+                    "settingInstanceTemplateId": "94f6f35c-4cee-4a61-930a-491b698c790a"
+                },
+                "choiceSettingValue": {
+                    "value": "com.apple.managedclient.preferences_enforcementlevel_1",
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "96ced765-4f68-441a-b9ad-b683cfdfa28f",
+                        "useTemplateDefault": false
+                    },
+                    "children": []
+                }
+            }
         },
-        "choiceSettingValue": {
-          "value": "com.apple.managedclient.preferences_enforcementlevel_1",
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "96ced765-4f68-441a-b9ad-b683cfdfa28f",
-            "useTemplateDefault": false
-          },
-          "children": [
-
-          ]
-        }
-      }
-    },
-    {
-      "id": "12",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "com.apple.managedclient.preferences_enforcementlevel_tamperprotection",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "3c4efab3-cf91-4540-b86d-54507c90bb4b"
+        {
+            "id": "12",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "com.apple.managedclient.preferences_enforcementlevel_tamperprotection",
+                "settingInstanceTemplateReference": {
+                    "settingInstanceTemplateId": "3c4efab3-cf91-4540-b86d-54507c90bb4b"
+                },
+                "choiceSettingValue": {
+                    "value": "com.apple.managedclient.preferences_enforcementlevel_tamperprotection_2",
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "6e25fd09-16f1-42fd-9ffe-954ee1c0b904",
+                        "useTemplateDefault": false
+                    },
+                    "children": []
+                }
+            }
         },
-        "choiceSettingValue": {
-          "value": "com.apple.managedclient.preferences_enforcementlevel_tamperprotection_2",
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "6e25fd09-16f1-42fd-9ffe-954ee1c0b904",
-            "useTemplateDefault": false
-          },
-          "children": [
-
-          ]
-        }
-      }
-    },
-    {
-      "id": "13",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "com.apple.managedclient.preferences_consumerexperience",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "1cb52ec2-c861-4c4a-9184-e4cc13eba6ad"
+        {
+            "id": "13",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "com.apple.managedclient.preferences_consumerexperience",
+                "settingInstanceTemplateReference": {
+                    "settingInstanceTemplateId": "1cb52ec2-c861-4c4a-9184-e4cc13eba6ad"
+                },
+                "choiceSettingValue": {
+                    "value": "com.apple.managedclient.preferences_consumerexperience_1",
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "95f4ea0a-5907-4008-931b-652105f937a0",
+                        "useTemplateDefault": false
+                    },
+                    "children": []
+                }
+            }
         },
-        "choiceSettingValue": {
-          "value": "com.apple.managedclient.preferences_consumerexperience_1",
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "95f4ea0a-5907-4008-931b-652105f937a0",
-            "useTemplateDefault": false
-          },
-          "children": [
-
-          ]
-        }
-      }
-    },
-    {
-      "id": "14",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "com.apple.managedclient.preferences_hidestatusmenuicon",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "1b9f3e2b-46e8-4346-935d-dd0bd8ad2443"
+        {
+            "id": "14",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "com.apple.managedclient.preferences_hidestatusmenuicon",
+                "settingInstanceTemplateReference": {
+                    "settingInstanceTemplateId": "1b9f3e2b-46e8-4346-935d-dd0bd8ad2443"
+                },
+                "choiceSettingValue": {
+                    "value": "com.apple.managedclient.preferences_hidestatusmenuicon_true",
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "fd30f322-4968-4479-8510-ad308ca8abe3",
+                        "useTemplateDefault": false
+                    },
+                    "children": []
+                }
+            }
         },
-        "choiceSettingValue": {
-          "value": "com.apple.managedclient.preferences_hidestatusmenuicon_true",
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "fd30f322-4968-4479-8510-ad308ca8abe3",
-            "useTemplateDefault": false
-          },
-          "children": [
-
-          ]
+        {
+            "id": "15",
+            "settingInstance": {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "com.apple.managedclient.preferences_userinitiatedfeedback",
+                "settingInstanceTemplateReference": {
+                    "settingInstanceTemplateId": "4423d695-27c2-4266-b253-bff098657834"
+                },
+                "choiceSettingValue": {
+                    "value": "com.apple.managedclient.preferences_userinitiatedfeedback_1",
+                    "settingValueTemplateReference": {
+                        "settingValueTemplateId": "41df6cea-c66a-44a6-b37b-c73c811a898c",
+                        "useTemplateDefault": false
+                    },
+                    "children": []
+                }
+            }
         }
-      }
-    },
-    {
-      "id": "15",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "com.apple.managedclient.preferences_userinitiatedfeedback",
-        "settingInstanceTemplateReference": {
-          "settingInstanceTemplateId": "4423d695-27c2-4266-b253-bff098657834"
-        },
-        "choiceSettingValue": {
-          "value": "com.apple.managedclient.preferences_userinitiatedfeedback_1",
-          "settingValueTemplateReference": {
-            "settingValueTemplateId": "41df6cea-c66a-44a6-b37b-c73c811a898c",
-            "useTemplateDefault": false
-          },
-          "children": [
-
-          ]
-        }
-      }
-    }
-  ]
+    ]
 }

--- a/intune-policies/microsoft-defender-antivirus-policies/NMM Defender Antivirus for macOS.json
+++ b/intune-policies/microsoft-defender-antivirus-policies/NMM Defender Antivirus for macOS.json
@@ -1,0 +1,365 @@
+{
+  "_wap_tags": "Defender for Endpoint",
+  "description": "This policy configures Microsoft Defender Antivirus settings on macOS devices to enhance security. It includes settings for exclusions, threat type settings merge policy, maximum on-demand scan threads, scanning after definition updates, archive scanning, antivirus engine enforcement level, enabling the antivirus, automatic sample submission, diagnostic level, automatic definition update, general enforcement level, tamper protection enforcement level, consumer experience adjustments, hiding the status menu icon, and user-initiated feedback.",
+  "name": "NMM Defender Antivirus for macOS",
+  "platforms": "macOS",
+  "settingCount": 16,
+  "technologies": "mdm,microsoftSense",
+  "templateReference": {
+    "templateId": "2d345ec2-c817-49e5-9156-3ed416dc972a_1",
+    "templateFamily": "endpointSecurityAntivirus",
+    "templateDisplayName": "Microsoft Defender Antivirus",
+    "templateDisplayVersion": "Version 1"
+  },
+  "settings": [
+    {
+      "id": "0",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "com.apple.managedclient.preferences_exclusionsmergepolicy",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "c07a6983-ac3e-4f38-be45-20954638dabd"
+        },
+        "choiceSettingValue": {
+          "value": "com.apple.managedclient.preferences_exclusionsmergepolicy_1",
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "effc409a-9169-43f0-a807-2a388875cf99",
+            "useTemplateDefault": false
+          },
+          "children": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "1",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance",
+        "settingDefinitionId": "com.apple.managedclient.preferences_threattypesettings",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "f2df12de-2704-4a13-9e10-21f4857122aa"
+        },
+        "groupSettingCollectionValue": [
+          {
+            "settingValueTemplateReference": null,
+            "children": [
+              {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "com.apple.managedclient.preferences_threattypesettings_item_key",
+                "settingInstanceTemplateReference": {
+                  "settingInstanceTemplateId": "675e2ada-1e8f-46eb-9348-ab0707c86ed0"
+                },
+                "choiceSettingValue": {
+                  "value": "com.apple.managedclient.preferences_threattypesettings_item_key_0",
+                  "settingValueTemplateReference": {
+                    "settingValueTemplateId": "45c09bfc-8cbd-4118-9396-17427d8c5795",
+                    "useTemplateDefault": false
+                  },
+                  "children": [
+
+                  ]
+                }
+              },
+              {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "com.apple.managedclient.preferences_threattypesettings_item_value",
+                "settingInstanceTemplateReference": {
+                  "settingInstanceTemplateId": "347d727a-70f7-4d22-af3d-5571052ce9d5"
+                },
+                "choiceSettingValue": {
+                  "value": "com.apple.managedclient.preferences_threattypesettings_item_value_0",
+                  "settingValueTemplateReference": {
+                    "settingValueTemplateId": "2d7b917e-affe-47d4-aa42-8468bc109dad",
+                    "useTemplateDefault": false
+                  },
+                  "children": [
+
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "2",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "com.apple.managedclient.preferences_threattypesettingsmergepolicy",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "65d9ddaf-0552-4e40-8575-71dd54b2ccb4"
+        },
+        "choiceSettingValue": {
+          "value": "com.apple.managedclient.preferences_threattypesettingsmergepolicy_1",
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "613bcf39-69ec-4a1f-8822-07789ae7f8cb",
+            "useTemplateDefault": false
+          },
+          "children": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "3",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
+        "settingDefinitionId": "com.apple.managedclient.preferences_maximumondemandscanthreads",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "e02fd3ba-4146-4b7d-9c7f-dffec96465e5"
+        },
+        "simpleSettingValue": {
+          "@odata.type": "#microsoft.graph.deviceManagementConfigurationIntegerSettingValue",
+          "value": 2,
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "fe25bbb2-f6de-480a-9153-11f90d7dab4e",
+            "useTemplateDefault": false
+          }
+        }
+      }
+    },
+    {
+      "id": "4",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "com.apple.managedclient.preferences_scanafterdefinitionupdate",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "65bc7d9e-a0fc-4e3f-b464-550c30589e3c"
+        },
+        "choiceSettingValue": {
+          "value": "com.apple.managedclient.preferences_scanafterdefinitionupdate_true",
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "1d05f27d-cc04-44a3-82f8-91df943b03e4",
+            "useTemplateDefault": false
+          },
+          "children": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "5",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "com.apple.managedclient.preferences_scanarchives",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "27ca9434-85a0-4175-999d-bbef8eb8d066"
+        },
+        "choiceSettingValue": {
+          "value": "com.apple.managedclient.preferences_scanarchives_true",
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "26bb4b38-6e8a-4e3d-9045-81314475b3fe",
+            "useTemplateDefault": false
+          },
+          "children": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "6",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "com.apple.managedclient.preferences_enforcementlevel_antivirusengine",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "a1bf7f4c-196e-4930-8395-a9b496433322"
+        },
+        "choiceSettingValue": {
+          "value": "com.apple.managedclient.preferences_enforcementlevel_antivirusengine_2",
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "440003a2-8406-47bb-a785-a45869556ead",
+            "useTemplateDefault": false
+          },
+          "children": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "7",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "com.apple.managedclient.preferences_enabled",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "9e424cc6-35b9-48ef-863c-73295aa9d2d7"
+        },
+        "choiceSettingValue": {
+          "value": "com.apple.managedclient.preferences_enabled_true",
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "7ea0a2aa-0953-4340-b590-522f040b0da3",
+            "useTemplateDefault": false
+          },
+          "children": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "8",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "com.apple.managedclient.preferences_automaticsamplesubmission",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "d5563bad-08c5-47de-8bbb-5d44e0f9a23a"
+        },
+        "choiceSettingValue": {
+          "value": "com.apple.managedclient.preferences_automaticsamplesubmission_true",
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "de57abd5-1a87-463e-96e7-e117524003ba",
+            "useTemplateDefault": false
+          },
+          "children": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "9",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "com.apple.managedclient.preferences_diagnosticlevel",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "c7a9a79b-20cf-461f-8021-94702a32543b"
+        },
+        "choiceSettingValue": {
+          "value": "com.apple.managedclient.preferences_diagnosticlevel_1",
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "5fc10db6-9ee5-434a-9ed0-1382bf72969e",
+            "useTemplateDefault": false
+          },
+          "children": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "10",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "com.apple.managedclient.preferences_automaticdefinitionupdateenabled",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "cc18c6dc-dca5-4845-9c78-c718c9447ddd"
+        },
+        "choiceSettingValue": {
+          "value": "com.apple.managedclient.preferences_automaticdefinitionupdateenabled_true",
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "112fd4a8-1393-49b6-9569-0d37266a6ad3",
+            "useTemplateDefault": false
+          },
+          "children": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "11",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "com.apple.managedclient.preferences_enforcementlevel",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "94f6f35c-4cee-4a61-930a-491b698c790a"
+        },
+        "choiceSettingValue": {
+          "value": "com.apple.managedclient.preferences_enforcementlevel_1",
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "96ced765-4f68-441a-b9ad-b683cfdfa28f",
+            "useTemplateDefault": false
+          },
+          "children": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "12",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "com.apple.managedclient.preferences_enforcementlevel_tamperprotection",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "3c4efab3-cf91-4540-b86d-54507c90bb4b"
+        },
+        "choiceSettingValue": {
+          "value": "com.apple.managedclient.preferences_enforcementlevel_tamperprotection_2",
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "6e25fd09-16f1-42fd-9ffe-954ee1c0b904",
+            "useTemplateDefault": false
+          },
+          "children": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "13",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "com.apple.managedclient.preferences_consumerexperience",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "1cb52ec2-c861-4c4a-9184-e4cc13eba6ad"
+        },
+        "choiceSettingValue": {
+          "value": "com.apple.managedclient.preferences_consumerexperience_1",
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "95f4ea0a-5907-4008-931b-652105f937a0",
+            "useTemplateDefault": false
+          },
+          "children": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "14",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "com.apple.managedclient.preferences_hidestatusmenuicon",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "1b9f3e2b-46e8-4346-935d-dd0bd8ad2443"
+        },
+        "choiceSettingValue": {
+          "value": "com.apple.managedclient.preferences_hidestatusmenuicon_true",
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "fd30f322-4968-4479-8510-ad308ca8abe3",
+            "useTemplateDefault": false
+          },
+          "children": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "15",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "com.apple.managedclient.preferences_userinitiatedfeedback",
+        "settingInstanceTemplateReference": {
+          "settingInstanceTemplateId": "4423d695-27c2-4266-b253-bff098657834"
+        },
+        "choiceSettingValue": {
+          "value": "com.apple.managedclient.preferences_userinitiatedfeedback_1",
+          "settingValueTemplateReference": {
+            "settingValueTemplateId": "41df6cea-c66a-44a6-b37b-c73c811a898c",
+            "useTemplateDefault": false
+          },
+          "children": [
+
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/intune-policies/policy-baselines/NMM For Defender for Endpoint.json
+++ b/intune-policies/policy-baselines/NMM For Defender for Endpoint.json
@@ -1,18 +1,20 @@
 {
-  "name": "For Defender",
-  "description": "Built-in policy baseline for Defender for Endpoint",
-  "tags": [ "Defender for Endpoint" ],
-  "baselineType": "ForDefenderForEndpoint",
-  "policies": [
-    "/intune-policies/compliance-policies/NMM Windows Advanced Compliancy with Defender.json",
-    "/intune-policies/application-control-policies/NMM Application Control (audit mode).json",
-    "/intune-policies/application-control-policies/NMM Enforce SmartScreen.json",
-    "/intune-policies/security-baseline-policies/NMM Force Bitlocker for fixed disks only.json",
-    "/intune-policies/macos-firewall-policies/NMM macOS Firewall.json",
-    "/intune-policies/attack-surface-reduction-rules-policies/NMM Attack Surface Reduction.json",
-    "/intune-policies/microsoft-defender-antivirus-policies/NMM Defender Antivirus for macOS.json",
-    "/intune-policies/microsoft-defender-antivirus-policies/NMM Defender Antivirus for Windows 10_11.json",
-    "/intune-policies/windows-firewall-policies/NMM Windows Defender Firewall.json",
-    "/intune-policies/endpoint-detection-and-response-policies/NMM Defender onboarding for Windows 10_11 (with specific secret).json"
-  ]
+    "name": "Defender for Endpoint",
+    "description": "Built-in policy baseline for Defender for Endpoint",
+    "tags": [
+        "Defender for Endpoint"
+    ],
+    "baselineType": "ForDefenderForEndpoint",
+    "policies": [
+        "/intune-policies/compliance-policies/NMM Windows Advanced Compliancy with Defender.json",
+        "/intune-policies/application-control-policies/NMM Application Control (audit mode).json",
+        "/intune-policies/application-control-policies/NMM Enforce SmartScreen.json",
+        "/intune-policies/security-baseline-policies/NMM Force Bitlocker for fixed disks only.json",
+        "/intune-policies/macos-firewall-policies/NMM macOS Firewall.json",
+        "/intune-policies/attack-surface-reduction-rules-policies/NMM Attack Surface Reduction.json",
+        "/intune-policies/microsoft-defender-antivirus-policies/NMM Defender Antivirus for macOS.json",
+        "/intune-policies/microsoft-defender-antivirus-policies/NMM Defender Antivirus for Windows 10_11.json",
+        "/intune-policies/windows-firewall-policies/NMM Windows Defender Firewall.json",
+        "/intune-policies/endpoint-detection-and-response-policies/NMM Defender onboarding for Windows 10_11 (with specific secret).json"
+    ]
 }

--- a/intune-policies/policy-baselines/NMM For Defender for Endpoint.json
+++ b/intune-policies/policy-baselines/NMM For Defender for Endpoint.json
@@ -1,0 +1,18 @@
+{
+  "name": "For Defender",
+  "description": "Built-in policy baseline for Defender for Endpoint",
+  "tags": [ "Defender for Endpoint" ],
+  "baselineType": "ForDefenderForEndpoint",
+  "policies": [
+    "/intune-policies/compliance-policies/NMM Windows Advanced Compliancy with Defender.json",
+    "/intune-policies/application-control-policies/NMM Application Control (audit mode).json",
+    "/intune-policies/application-control-policies/NMM Enforce SmartScreen.json",
+    "/intune-policies/security-baseline-policies/NMM Force Bitlocker for fixed disks only.json",
+    "/intune-policies/macos-firewall-policies/NMM macOS Firewall.json",
+    "/intune-policies/attack-surface-reduction-rules-policies/NMM Attack Surface Reduction.json",
+    "/intune-policies/microsoft-defender-antivirus-policies/NMM Defender Antivirus for macOS.json",
+    "/intune-policies/microsoft-defender-antivirus-policies/NMM Defender Antivirus for Windows 10_11.json",
+    "/intune-policies/windows-firewall-policies/NMM Windows Defender Firewall.json",
+    "/intune-policies/endpoint-detection-and-response-policies/NMM Defender onboarding for Windows 10_11 (with specific secret).json"
+  ]
+}


### PR DESCRIPTION
Added new defender policies:

NMM Application Control (audit mode)
NMM Enforce SmartScreen
NMM macOS Firewall
NMM Defender Antivirus for macOS
NMM Defender onboarding for Windows 10_11 (with the customer specific secret)

Added built-in policy baseline Defender for Endpoint